### PR TITLE
feat: add Kafka log appender

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
         because("required by json-schema-validator")
     }
     implementation(libs.aedile)
+    implementation("org.apache.kafka:kafka-clients:3.7.0")
 
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)

--- a/src/main/kotlin/com/company/tp/security/logging/KafkaLogAppender.kt
+++ b/src/main/kotlin/com/company/tp/security/logging/KafkaLogAppender.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.company.tp.security.logging
+
+import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import java.util.Properties
+
+class KafkaLogAppender(
+    private val config: KafkaLoggingProperties,
+    private val producerProps: Properties,
+) : AppenderBase<ILoggingEvent>() {
+
+    private lateinit var layout: PatternLayout
+    private lateinit var producer: KafkaProducer<String, String>
+
+    override fun start() {
+        super.start()
+        layout = PatternLayout().also {
+            it.context = context
+            it.pattern = config.pattern
+            it.start()
+        }
+        producer = KafkaProducer(producerProps)
+    }
+
+    override fun stop() {
+        producer.close()
+        super.stop()
+    }
+
+    override fun append(eventObject: ILoggingEvent) {
+        val msg = layout.doLayout(eventObject)
+        producer.send(ProducerRecord(config.topic, msg))
+    }
+}

--- a/src/main/kotlin/com/company/tp/security/logging/KafkaLoggingAutoConfiguration.kt
+++ b/src/main/kotlin/com/company/tp/security/logging/KafkaLoggingAutoConfiguration.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.company.tp.security.logging
+
+import ch.qos.logback.classic.AsyncAppender
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.filter.ThresholdFilter
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SslConfigs
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import java.util.Properties
+
+@Configuration
+@ConditionalOnProperty(prefix = "logging.kafka", name = ["enabled"], havingValue = "true")
+@EnableConfigurationProperties(KafkaLoggingProperties::class)
+class KafkaLoggingAutoConfiguration(
+    private val properties: KafkaLoggingProperties,
+) {
+
+    init {
+        val context = LoggerFactory.getILoggerFactory() as LoggerContext
+
+        val producerProps = Properties().apply {
+            put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, properties.bootstrapServers)
+            put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+            put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
+            put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL")
+            properties.ssl.keystoreLocation?.let { put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, it) }
+            properties.ssl.keystorePassword?.let { put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, it) }
+            properties.ssl.keyPassword?.let { put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, it) }
+            properties.ssl.truststoreLocation?.let { put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, it) }
+            properties.ssl.truststorePassword?.let { put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, it) }
+        }
+
+        val kafkaAppender = KafkaLogAppender(properties, producerProps).apply {
+            this.context = context
+            start()
+        }
+
+        val asyncAppender = AsyncAppender().apply {
+            this.context = context
+            queueSize = properties.queueSize
+            discardingThreshold = properties.discardingThreshold
+            addAppender(kafkaAppender)
+            addFilter(
+                ThresholdFilter().apply {
+                    setLevel(properties.level)
+                    start()
+                },
+            )
+            start()
+        }
+
+        context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).addAppender(asyncAppender)
+    }
+}

--- a/src/main/kotlin/com/company/tp/security/logging/KafkaLoggingProperties.kt
+++ b/src/main/kotlin/com/company/tp/security/logging/KafkaLoggingProperties.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.company.tp.security.logging
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("logging.kafka")
+data class KafkaLoggingProperties(
+    val enabled: Boolean = false,
+    val topic: String = "",
+    val bootstrapServers: String = "",
+    val queueSize: Int = 256,
+    val discardingThreshold: Int = 0,
+    val pattern: String = "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n",
+    val level: String = "INFO",
+    val ssl: SslProperties = SslProperties(),
+) {
+    data class SslProperties(
+        val keystoreLocation: String? = null,
+        val keystorePassword: String? = null,
+        val keyPassword: String? = null,
+        val truststoreLocation: String? = null,
+        val truststorePassword: String? = null,
+    )
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.company.tp.security.logging.KafkaLoggingAutoConfiguration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,3 +75,22 @@ verifier.validation.sdJwtVc.typeMetadata.resolution.cache.maxEntries=10
 #verifier.validation.sdJwtVc.typeMetadata.resolution.vcts[0].url=https://dev.issuer-backend.eudiw.dev/type-metadata/urn:eudi:pid:1
 verifier.validation.sdJwtVc.typeMetadata.jsonSchema.validation.enabled=true
 
+#
+# Kafka logging configuration
+#
+logging.kafka.enabled=false
+logging.kafka.topic=
+#logging.kafka.topic=example-topic
+logging.kafka.bootstrap-servers=
+#logging.kafka.bootstrap-servers=localhost:9092
+logging.kafka.queue-size=256
+logging.kafka.discarding-threshold=0
+logging.kafka.pattern=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n
+logging.kafka.level=INFO
+logging.kafka.ssl.keystore-location=
+#logging.kafka.ssl.keystore-location=file:/path/to/keystore.jks
+logging.kafka.ssl.keystore-password=
+logging.kafka.ssl.key-password=
+logging.kafka.ssl.truststore-location=
+#logging.kafka.ssl.truststore-location=file:/path/to/truststore.jks
+logging.kafka.ssl.truststore-password=

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- move Kafka logging components to `com.company.tp.security` package and register auto-configuration
- provide `logback.xml` for configuring loggers and patterns
- add Kafka logging properties with placeholders for brokers, topic and SSL credentials

## Testing
- `./gradlew spotlessCheck`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b01c30e61c832b9adb4a5899f86f12